### PR TITLE
Clang driver.

### DIFF
--- a/make_beos.sh
+++ b/make_beos.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 gcc -Wall -ansi -pedantic src/tools/txt2c.c -o src/tools/txt2c
-src/tools/txt2c src/base.lua src/tools.lua src/driver_gcc.lua src/driver_cl.lua > src/internal_base.h
+src/tools/txt2c src/base.lua src/tools.lua src/driver_gcc.lua src/driver_clang.lua src/driver_cl.lua > src/internal_base.h
 gcc -Wall -ansi -pedantic src/lua/*.c src/*.c -o bam -I src/lua -lpthread -O2 $*

--- a/make_unix.sh
+++ b/make_unix.sh
@@ -18,5 +18,5 @@ fi
 # the actual compile
 echo compiling using $CC...
 $CC -Wall -ansi -pedantic src/tools/txt2c.c -o src/tools/txt2c
-src/tools/txt2c src/base.lua src/tools.lua src/driver_gcc.lua src/driver_cl.lua > src/internal_base.h
+src/tools/txt2c src/base.lua src/tools.lua src/driver_gcc.lua src/driver_clang.lua src/driver_cl.lua > src/internal_base.h
 $CC -Wall -ansi -pedantic src/*.c src/lua/*.c -o bam -I src/lua -lm -lpthread -ldl -O2 -rdynamic $*

--- a/make_win32_dmc.bat
+++ b/make_win32_dmc.bat
@@ -1,7 +1,7 @@
 @REM --- Batch file that builds bam using Digital Mars C Compiler
 
 @dmc -L/NOL -A src\tools\txt2c.c -o src\tools\txt2c.exe
-@src\tools\txt2c.exe src\base.lua src\tools.lua src\driver_gcc.lua src\driver_cl.lua > src\internal_base.h
+@src\tools\txt2c.exe src\base.lua src\tools.lua src\driver_gcc.lua src/driver_clang.lua src\driver_cl.lua > src\internal_base.h
 
 @REM ------ Generate fileliest
 @move src\tools\txt2c.c src\tools\txt2c.c.temp > nul

--- a/make_win32_mingw.bat
+++ b/make_win32_mingw.bat
@@ -1,3 +1,3 @@
 @gcc -ansi -pedantic -Wall src/tools/txt2c.c -o src/tools/txt2c
-@src\tools\txt2c.exe src/base.lua src/tools.lua src/driver_gcc.lua src/driver_cl.lua > src/internal_base.h
+@src\tools\txt2c.exe src/base.lua src/tools.lua src/driver_gcc.lua src/driver_clang.lua src/driver_cl.lua > src/internal_base.h
 @gcc -ansi -pedantic -Wall src/*.c src/lua/*.c -o bam -I src/lua/

--- a/make_win32_msvc.bat
+++ b/make_win32_msvc.bat
@@ -30,7 +30,7 @@ call %VSPATH%vsvars32.bat
 :compile
 @echo === building bam ===
 @cl /D_CRT_SECURE_NO_DEPRECATE /O2 /nologo src/tools/txt2c.c /Fesrc/tools/txt2c.exe
-@src\tools\txt2c src/base.lua src/tools.lua src/driver_gcc.lua src/driver_cl.lua > src\internal_base.h
+@src\tools\txt2c src/base.lua src/tools.lua src/driver_gcc.lua src/driver_clang.lua src/driver_cl.lua > src\internal_base.h
 
 @REM /DLUA_BUILD_AS_DLL = export lua functions
 @REM /W3 = Warning level 3

--- a/make_win64_msvc.bat
+++ b/make_win64_msvc.bat
@@ -37,7 +37,7 @@ exit
 :compile
 @echo === building bam ===
 @cl /D_CRT_SECURE_NO_DEPRECATE /O2 /nologo src/tools/txt2c.c /Fesrc/tools/txt2c.exe
-@src\tools\txt2c src/base.lua src/tools.lua src/driver_gcc.lua src/driver_cl.lua > src\internal_base.h
+@src\tools\txt2c src/base.lua src/tools.lua src/driver_gcc.lua src/driver_clang.lua src/driver_cl.lua > src\internal_base.h
 
 @REM /DLUA_BUILD_AS_DLL = export lua functions
 @REM /W3 = Warning level 3

--- a/src/driver_clang.lua
+++ b/src/driver_clang.lua
@@ -1,0 +1,28 @@
+function DriverClang_CTest(code, options)
+	local f = io.open("_test.c", "w")
+	f:write(code)
+	f:write("\n")
+	f:close()
+	local ret = ExecuteSilent("clang _test.c -o _test " .. options)
+	os.remove("_test.c")
+	os.remove("_test")
+	return ret==0
+end
+
+function SetDriversClang(settings)
+	SetDriversGCC(settings)
+
+	if settings.cc then
+		settings.cc.exe_c = "clang"
+		settings.cc.exe_cxx = "clang++"
+		settings.cc.DriverCTest = DriverClang_CTest
+	end
+
+	if settings.link then
+		settings.link.exe = "clang++"
+	end
+
+	if settings.dll then
+		settings.dll.exe = "clang++"
+	end
+end


### PR DESCRIPTION
Clang is mostly command-line compatible; simply swapping the exe works for Teeworlds.
