### PR TITLE
Should be dll on windows

### DIFF
--- a/src/driver_gcc.lua
+++ b/src/driver_gcc.lua
@@ -108,6 +108,9 @@ function SetDriversGCC(settings)
 		if platform == "macosx" then
 			settings.dll.prefix = "lib"
 			settings.dll.extension = ".dylib"
+		elseif family == "windows" then
+			settings.dll.prefix = ""
+			settings.dll.extension = ".dll"
 		else
 			settings.dll.prefix = ""
 			settings.dll.extension = ".so"


### PR DESCRIPTION
On mingw, bam output `.so` for shareddll. But it should be `.dll`.
