### PR TITLE
Strict ansi compiling doesn't work for MinGW. Removed.

### DIFF
--- a/make_win32_mingw.bat
+++ b/make_win32_mingw.bat
@@ -1,3 +1,3 @@
 @gcc -ansi -pedantic -Wall src/tools/txt2c.c -o src/tools/txt2c
 @src\tools\txt2c.exe src/base.lua src/tools.lua src/driver_gcc.lua src/driver_clang.lua src/driver_cl.lua > src/internal_base.h
-@gcc -ansi -pedantic -Wall src/*.c src/lua/*.c -o bam -I src/lua/
+@gcc -pedantic -Wall src/*.c src/lua/*.c -o bam -I src/lua/


### PR DESCRIPTION
It works but not sire if its the right side to fix the problem on