### PR TITLE
check for regular file before adding dependencies from includes

### DIFF
--- a/src/dep_cpp.c
+++ b/src/dep_cpp.c
@@ -245,7 +245,7 @@ static int node_findfile(struct GRAPH *graph, const char *filename, struct NODE 
 
 	/* then check the file system */
 	*timestamp = file_timestamp(filename);
-	if(*timestamp)
+	if(*timestamp && file_isregular(filename))
 		return 1;
 
 	return 0;

--- a/src/support.c
+++ b/src/support.c
@@ -312,6 +312,14 @@ time_t file_timestamp(const char *filename)
 #endif
 }
 
+int file_isregular(const char *filename)
+{
+	struct stat s;
+	if(stat(filename, &s) == 0)
+		return S_ISREG(s.st_mode);
+	return 0;
+}
+
 int file_createdir(const char *path)
 {
 	int r;

--- a/src/support.h
+++ b/src/support.h
@@ -45,6 +45,7 @@ int64 time_freq();
 /* filesystem and timestamps */
 time_t timestamp();
 time_t file_timestamp(const char *filename);
+int file_isregular(const char *path);
 int file_createdir(const char *path);
 int file_createpath(const char *output_name);
 void file_touch(const char *filename);


### PR DESCRIPTION
If there is a directory on the include path with the same name as an include, bam will incorrectly add it do the dependency graph. Later bam tries to fopen() and fseek() the directory, leading to undefined behavior.

This change ensures that a file is a regular file before inclusion in the dependency graph. Note that stat() is used instead of lstat() so symbolic links will still be followed.