### PR TITLE
Fixed bug where SetDefaultDrivers() would not detect MSVC correctly

### DIFF
--- a/src/tools.lua
+++ b/src/tools.lua
@@ -4,7 +4,7 @@ function SetDefaultDrivers(settings)
 	-- check for compilers first time
 	if _checked_default_drivers == false then
 		_checked_default_drivers = true
-		if ExecuteSilent("cl") == 0 then
+		if ExecuteSilent("cl") >= 0 then
 			SetDriversDefault = SetDriversCL
 		elseif ExecuteSilent("gcc -v") == 0 then
 			SetDriversDefault = SetDriversGCC


### PR DESCRIPTION
Failed on my installed version, MSVC 2010 ( cl.exe Compiler Version 16.00.30319.01 for x64 ).

This version of cl do not return 0 if run without any input but the error-code 2.
This seems to be the best fix since ExecuteSilent() would return a negative value if the binary could not run.

I couldn't find a way to get cl.exe to run with 0 as an error-code.