### PR TITLE
Cachesplit - bugfix - outputchache file overwrite warning

### DIFF
--- a/src/cache.c
+++ b/src/cache.c
@@ -605,7 +605,12 @@ struct CACHEINFO_OUTPUT *outputcache_find_byhash(struct OUTPUTCACHE *outputcache
 	{
 		index = low + (high - low) / 2;
 		if(hashid < outputcache->info[index].hashid)
-			high = index - 1;
+		{
+			if(index == 0)
+				break;
+			else
+				high = index - 1;
+		}
 		else if(hashid > outputcache->info[index].hashid)
 			low = index + 1;
 		else

--- a/src/cache.c
+++ b/src/cache.c
@@ -400,6 +400,7 @@ struct OUTPUTCACHE
 {
 	struct CACHEINFO_OUTPUT *info;
 	unsigned count;
+	time_t cache_file_stamp;
 };
 
 static int output_hash_compare(const void * a, const void * b)
@@ -485,6 +486,12 @@ int outputcache_save(const char *filename, struct OUTPUTCACHE *oldcache, struct 
 	struct CACHEINFO_OUTPUT * final;
 	unsigned finalcount;
 
+	time_t current_stamp = file_timestamp(filename);
+	if(oldcache && oldcache->cache_file_stamp != current_stamp)
+		printf("%s: warning: cache file '%s' has been changed since cache load, will be overwritten (%08x,%08x), is bam called from bam?\n", session.name, filename, (unsigned)oldcache->cache_file_stamp, (unsigned)current_stamp);
+	else if( !oldcache && current_stamp != 0 )
+		printf("%s: warning: cache file '%s' was missing on cache load but has appeared during the run, will be overwritten (%08x), is bam called from bam?\n", session.name, filename, (unsigned)current_stamp);
+	
 	fp = io_open_write(filename);
 	if(!io_valid(fp))
 		return -1;
@@ -578,6 +585,7 @@ struct OUTPUTCACHE *outputcache_load(const char *filename)
 	cache = (struct OUTPUTCACHE*)malloc(sizeof(struct OUTPUTCACHE));
 	cache->info = (struct CACHEINFO_OUTPUT *)((char*)buffer + sizeof(bamheader));
 	cache->count = payloadsize /  sizeof(struct CACHEINFO_OUTPUT);
+	cache->cache_file_stamp = file_timestamp(filename);
 
 	if(validate_outputcache(cache->info, cache->count))
 	{

--- a/src/cache.h
+++ b/src/cache.h
@@ -28,7 +28,7 @@ int depcache_do_dependency(
 
 
 /* output cache */
-int outputcache_save(const char *filename, struct OUTPUTCACHE *oldcache, struct GRAPH *graph);
-struct OUTPUTCACHE *outputcache_load(const char *filename);
+int outputcache_save(const char *filename, struct OUTPUTCACHE *oldcache, struct GRAPH *graph, time_t cache_timestamp);
+struct OUTPUTCACHE *outputcache_load(const char *filename, time_t *cache_timestamp);
 void outputcache_free(struct OUTPUTCACHE *outputcache);
 struct CACHEINFO_OUTPUT *outputcache_find_byhash(struct OUTPUTCACHE *outputcache, hash_t hashid);

--- a/src/main.c
+++ b/src/main.c
@@ -711,6 +711,7 @@ static int bam(const char *scriptfile, const char **targets, int num_targets)
 	int build_error = 0;
 	int setup_error = 0;
 	int report_done = 0;
+	time_t outputcache_timestamp = 0;
 
 	/* build time */
 	time_t starttime  = time(0x0);
@@ -735,7 +736,6 @@ static int bam(const char *scriptfile, const char **targets, int num_targets)
 	lua_atpanic(context.lua, lf_panicfunc);
 
 	/* load cache (thread?) */
-	time_t outputcache_timestamp = 0;
 	if(option_no_cache == 0)
 	{
 		/* create a hash of all the external variables that can cause the

--- a/src/main.c
+++ b/src/main.c
@@ -735,6 +735,7 @@ static int bam(const char *scriptfile, const char **targets, int num_targets)
 	lua_atpanic(context.lua, lf_panicfunc);
 
 	/* load cache (thread?) */
+	time_t outputcache_timestamp = 0;
 	if(option_no_cache == 0)
 	{
 		/* create a hash of all the external variables that can cause the
@@ -753,7 +754,7 @@ static int bam(const char *scriptfile, const char **targets, int num_targets)
 		event_end(0, "depcache load", NULL);
 
 		event_begin(0, "outputcache load", outputcache_filename);
-		context.outputcache = outputcache_load(outputcache_filename);
+		context.outputcache = outputcache_load(outputcache_filename, &outputcache_timestamp);
 		event_end(0, "outputcache load", NULL);
 	}
 
@@ -825,7 +826,7 @@ static int bam(const char *scriptfile, const char **targets, int num_targets)
 		event_end(0, "depcache save", NULL);
 
 		event_begin(0, "outputcache save", outputcache_filename);
-		outputcache_save(outputcache_filename, context.outputcache, context.graph);
+		outputcache_save(outputcache_filename, context.outputcache, context.graph, outputcache_timestamp);
 		event_end(0, "outputcache save", NULL);
 	}
 	


### PR DESCRIPTION
Fixed wraparound in binary search.
Added warning when overwriting shared cache file (checking timestamps).