### PR TITLE
Fix compilation issue when using Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ CFLAGS += $(LUA_CFLAGS)
 # objects
 TARGETS = bam
 BAM_OBJ = $(patsubst %.c,%.o,$(wildcard src/*.c))
-TXT2C_LUA = $(wildcard src/*.lua)
+TXT2C_LUA = src/base.lua src/tools.lua src/driver_gcc.lua src/driver_clang.lua src/driver_cl.lua src/driver_solstudio.lua src/driver_xlc.lua
 
 
 # make rules


### PR DESCRIPTION
The compilation output depends on the order of the TXT2C_LUA files.
For example if tools.lua is listed before base.lua, this leads to
incomplete compilation.

This commit hardcodes the order of lua files in Makefile like it's
done in make_unix.sh.

Fixes #116.