### PR TITLE
Remove _test.exe generated by gcc test

### DIFF
--- a/src/driver_gcc.lua
+++ b/src/driver_gcc.lua
@@ -29,6 +29,7 @@ function DriverGCC_CTest(code, options)
 	f:close()
 	local ret = ExecuteSilent("gcc _test.c -o _test " .. options)
 	os.remove("_test.c")
+	os.remove("_test.exe")
 	os.remove("_test")
 	return ret==0
 end


### PR DESCRIPTION
Source:

> add `os.remove("_test.exe")` to [bam/src/driver_gcc.lua](https://github.com/matricks/bam/blob/master/src/driver_gcc.lua)
> like this: [gist](https://gist.github.com/EbrahimBGA/cfb56d1fc621be1625decd739ee3beea/revisions)


~~ @EbrahimBGA in https://github.com/teeworlds/teeworlds/pull/1535#issuecomment-433733665