### PR TITLE
Multioutput dependency fix

### DIFF
--- a/make_win64_msvc_dbg.bat
+++ b/make_win64_msvc_dbg.bat
@@ -1,0 +1,62 @@
+@echo off
+
+@@REM Check for Visual Studio
+call set "VSPATH="
+if defined VS140COMNTOOLS ( if not defined VSPATH (
+	call set "VSPATH=%%VS140COMNTOOLS%%"
+) )
+if defined VS120COMNTOOLS ( if not defined VSPATH (
+	call set "VSPATH=%%VS120COMNTOOLS%%"
+) )
+if defined VS110COMNTOOLS ( if not defined VSPATH (
+	call set "VSPATH=%%VS110COMNTOOLS%%"
+) )
+if defined VS100COMNTOOLS ( if not defined VSPATH (
+	call set "VSPATH=%%VS100COMNTOOLS%%"
+) )
+if defined VS90COMNTOOLS ( if not defined VSPATH (
+	call set "VSPATH=%%VS90COMNTOOLS%%"
+) )
+if defined VS80COMNTOOLS ( if not defined VSPATH (
+	call set "VSPATH=%%VS80COMNTOOLS%%"
+) )
+
+@REM check if we already have the tools in the environment
+if exist "%VCINSTALLDIR%" (
+	goto compile
+)
+
+if not defined VSPATH (
+	echo You need Microsoft Visual Studio 8, 9, 10, 11, 12, 13 or 15 installed
+	pause
+	exit
+)
+
+@REM set up the environment
+if exist "%VSPATH%..\..\vc\vcvarsall.bat" (
+	call "%%VSPATH%%..\..\vc\vcvarsall.bat" amd64
+	goto compile
+)
+
+echo Unable to set up the environment
+pause
+exit
+
+:compile
+@echo === building bam ===
+@cl /D_CRT_SECURE_NO_DEPRECATE /O2 /nologo src/tools/txt2c.c /Fesrc/tools/txt2c.exe
+@src\tools\txt2c src/base.lua src/tools.lua src/driver_gcc.lua src/driver_clang.lua src/driver_cl.lua > src\internal_base.h
+
+@REM /DLUA_BUILD_AS_DLL = export lua functions
+@REM /W3 = Warning level 3
+@REM /Ox = max optimizations
+@REM /TC = compile as c
+@REM /Zi = generate debug database
+@REM /GS- = no stack checks
+@REM /GL = Whole program optimization (ltcg)
+@REM /LTCG = link time code generation
+@cl /D_CRT_SECURE_NO_DEPRECATE /DLUA_BUILD_AS_DLL /W3 /O0 /DEBUG /TC /Zi /GS- /GL /nologo /I src/lua src/*.c src/lua/*.c /Febam.exe /link Advapi32.lib /LTCG
+
+@REM clean up
+@del bam.exp
+@del *.obj

--- a/scripts/test.py
+++ b/scripts/test.py
@@ -243,6 +243,7 @@ test("deadlock")
 test("addorder")
 test("import")
 test("multipleoutput")
+test("multipleoutput_deps")
 test("missingoutput", "", 1)
 
 if len(failed_tests):

--- a/scripts/test.py
+++ b/scripts/test.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-import os, sys, shutil, subprocess
+import os, sys, shutil, subprocess, io
 
 extra_bam_flags = ""
 src_path = "tests"
@@ -36,8 +36,8 @@ def copytree(src, dst):
 				copytree(srcname, dstname)
 			else:
 				shutil.copy2(srcname, dstname)
-		except (IOError, os.error), why:
-			print "Can't copy %s to %s: %s" % (`srcname`, `dstname`, str(why))
+		except (IOError, os.error) as why:
+			print("Can't copy %s to %s: %s" % (repr(srcname), repr(dstname), str(why)))
 
 
 def run_bam(testname, flags):
@@ -46,7 +46,7 @@ def run_bam(testname, flags):
 	os.chdir(output_path+"/"+testname)
 	
 	p = subprocess.Popen(bam+" "+flags, stdout=subprocess.PIPE, shell=True, stderr=subprocess.STDOUT)
-	report = p.stdout.readlines()
+	report = io.TextIOWrapper(p.stdout, encoding='ascii').readlines()
 	p.wait()
 	ret = p.returncode
 	os.chdir(olddir)
@@ -64,59 +64,59 @@ def test(name, moreflags="", should_fail=0):
 	os.chdir(output_path+"/"+name)
 	cmdline = bam+" -t -v "+extra_bam_flags+" " + moreflags
 	
-	print name + ":",
+	print(name + ":", end=' ')	
 	p = subprocess.Popen(cmdline, stdout=subprocess.PIPE, shell=True, stderr=subprocess.STDOUT)
-	report = p.stdout.readlines()
+	report = io.TextIOWrapper(p.stdout, encoding='ascii').readlines()
 	p.wait()
 	ret = p.returncode
 	
 	os.chdir(olddir)
 	
 	if (should_fail and not ret) or (not should_fail and ret):
-		print " FAILED!"
+		print(" FAILED!")
 		for l in report:
-			print "\t", l,
+			print("\t", l, end=' ')
 		failed_tests += [name + "(returned %d)" % ret]
 	else:
-		print " ok"
+		print(" ok")
 
 def difftest(name, flags1, flags2):
 	global failed_tests
 	if len(tests) and not name in tests:
 		return
 	testname = "difftest: %s '%s' vs '%s': "%(name, flags1, flags2)
-	print testname,
+	print(testname, end=' ')
 	ret1, report1 = run_bam(name, flags1)
 	ret2, report2 = run_bam(name, flags2)
 	
 	if ret1:
-		print "FAILED! '%s' returned %d" %(flags1, ret1)
+		print("FAILED! '%s' returned %d" %(flags1, ret1))
 		failed_tests += [testname]
 		return
 	
 	if ret2:
-		print "FAILED! '%s' returned %d" %(flags2, ret2)
+		print("FAILED! '%s' returned %d" %(flags2, ret2))
 		failed_tests += [testname]
 		return
 	
 	if len(report1) != len(report2):
-		print "FAILED! %d lines vs %d lines" % (len(report1), len(report2))
+		print("FAILED! %d lines vs %d lines" % (len(report1), len(report2)))
 		failed_tests += [testname]
 		return
 	
 	failed = 0
-	for i in xrange(0, len(report1)):
+	for i in range(0, len(report1)):
 		if report1[i] != report2[i]:
 			if not failed:
-				print "FAILED!"
-			print "1:", report1[i].strip()
-			print "2:", report2[i].strip()
+				print("FAILED!")
+			print("1:", report1[i].strip())
+			print("2:", report2[i].strip())
 			failed += 1
 			
 	if failed:
 		failed_tests += [testname]
 	else:
-		print "ok"
+		print("ok")
 
 def unittests():
 	global failed_tests
@@ -129,7 +129,7 @@ def unittests():
 	
 	tests = []
 	state = 0
-	for line in file('src/base.lua'):
+	for line in open( 'src/base.lua', 'r'):
 		if state == 0:
 			if "@UNITTESTS" in line:
 				state = 1
@@ -157,24 +157,24 @@ def unittests():
 	os.chdir(output_path+"/unit")
 	
 	for test in tests:
-		f = file("bam.lua", "w")
+		f = open("bam.lua", "w")
 		if test.catch != None:
-			print >>f, "print(\"CATCH:\", %s)"%(test.line)
+			print("print(\"CATCH:\", %s)"%(test.line), file=f)
 		else:
-			print >>f, test.line
-		print >>f, 'DefaultTarget(PseudoTarget("Test"))'
+			print(test.line, file=f)
+		print('DefaultTarget(PseudoTarget("Test"))', file=f)
 		f.close()
 
-		print  "%s:"%(test.line),
+		print("%s:"%(test.line), end=' ')
 		p = subprocess.Popen(bam + " --dry", stdout=subprocess.PIPE, shell=True, stderr=subprocess.STDOUT)
-		report = p.stdout.readlines()
+		report = io.TextIOWrapper(p.stdout, encoding='ascii').readlines()
 		p.wait()
 		ret = p.returncode
 		
 		failed = False
 		if ret != test.err:
 			failed = True
-			print "FAILED! error %d != %d" % (test.err, ret)
+			print("FAILED! error %d != %d" % (test.err, ret))
 		
 		if test.catch != None:
 			found = False
@@ -185,7 +185,7 @@ def unittests():
 					if catched == test.catch:
 						found = True
 					else:
-						print "FAILED! catch '%s' != '%s'" % (test.catch, catched)
+						print("FAILED! catch '%s' != '%s'" % (test.catch, catched))
 						
 			if not found:
 				failed = True
@@ -198,16 +198,16 @@ def unittests():
 			
 			if not found:
 				failed = True
-				print "FAILED! could not find '%s' in output" % (test.find)
+				print("FAILED! could not find '%s' in output" % (test.find))
 		if failed or verbose:
 			if failed:
 				failed_tests += [test.line]
 			else:
-				print "",
+				print("", end=' ')
 			for l in report:
-				print "\t", l.rstrip()
+				print("\t", l.rstrip())
 		else:
-			print "ok"
+			print("ok")
 			
 
 	os.chdir(olddir)
@@ -246,11 +246,11 @@ test("multipleoutput")
 test("missingoutput", "", 1)
 
 if len(failed_tests):
-	print "FAILED TESTS:"
+	print("FAILED TESTS:")
 	for t in failed_tests:
-		print "\t"+t
+		print("\t"+t)
 	sys.exit(1)
 else:
-	print "ALL TESTS PASSED!"
+	print("ALL TESTS PASSED!")
 	sys.exit(0)
 

--- a/src/luafuncs.c
+++ b/src/luafuncs.c
@@ -232,6 +232,8 @@ int lf_add_output(lua_State *L)
 	i = node_create(&other_output, context->graph, filename, output->job, TIMESTAMP_NONE);
 	handle_node_errors(L, i, 2);
 
+	node_inherit_dependencies(other_output, output);
+	
 	return 0;
 }
 

--- a/src/node.h
+++ b/src/node.h
@@ -221,6 +221,7 @@ struct NODE *node_find(struct GRAPH *graph, const char *filename);
 struct NODE *node_find_byhash(struct GRAPH *graph, hash_t hashid);
 struct NODE *node_get(struct GRAPH *graph, const char *filename);
 struct NODE *node_add_dependency(struct NODE *node, struct NODE *depnode);
+struct NODE *node_inherit_dependencies(struct NODE *node, struct NODE *sourcenode);
 void node_cached(struct NODE *node);
 
 /* */

--- a/tests/multipleoutput_deps/bam.lua
+++ b/tests/multipleoutput_deps/bam.lua
@@ -1,0 +1,39 @@
+-- this is a test for a bug where job deps where not forfilled for multi-output jobs when you only dependended on one of the non-primary outputs.
+-- bam would run the job without running the main job node deps. In this test we have a job creating output_source1, and then a multi-output job 
+-- with output3 as primary and then output4 as secondary outputs. The primary node is dependent on output_source1, but we only depend on the 
+-- second output. Second case is with all outputs added in AddJob, that case works. Third is adding the deps after all the outputs are added,
+-- behaves like the first
+
+local cat_cmd = ''
+if family == 'windows' then
+	cat_cmd = 'type'
+else 
+	cat_cmd = 'cat'
+end
+
+-- case 1 (output added after)
+AddJob("output_source_1", "testing source 1", "echo hello source 1 > output_source_1")
+
+AddJob("output_1_1", "testing 2", cat_cmd .. " output_source_1 > output_1_1 && " .. cat_cmd .. " output_source_1 >output_1_2", "output_source_1" )
+AddOutput("output_1_1", "output_1_2")
+
+
+-- case 2 (output added inline)
+AddJob("output_source_2", "testing source 2", "echo hello source 1 > output_source_2")
+
+AddJob({"output_2_1", "output_2_2"}, "testing 2", cat_cmd .. " output_source_2 > output_2_1 && " .. cat_cmd .. " output_source_2 >output_2_2", "output_source_2" )
+
+
+-- case 3 (deps added last)
+AddJob("output_source_3", "testing source 3", "echo hello source 1 > output_source_3")
+
+AddJob({"output_3_1", "output_3_2"}, "testing 3", cat_cmd .. " output_source_3 > output_3_1 && " .. cat_cmd .. " output_source_3 >output_3_2" )
+AddDependency( "output_3_1", "output_source_3" )
+
+
+PseudoTarget( 'test_target', {"output_1_2", "output_2_2", "output_3_2" } )
+--PseudoTarget( 'test_target', {"output_1_2"} )
+--PseudoTarget( 'test_target', {"output_2_2"} )
+--PseudoTarget( 'test_target', {"output_3_2"} )
+
+DefaultTarget("test_target")


### PR DESCRIPTION
Depending on how you add outputs and dependencies, only the case where you add all outputs and all deps in AddJob() works as expected. If you add an output using AddOutput or add a dep with AddDepencency not all outputs will have all deps. If these deps are jobs they might not be fulfilled before the jobs is run if only secondary outputs are used. See "Added test case for multi-output dep propagation bug." for testcase over these three cases. I'm not entirely sure if the fix in "Fixed dependency bug with multiple outputs, where secondary output of…" is the right one, but it produces the same structure with --debug-nodes structure for all three cases at least. --debug-nodes should probably check that all outputs have the same deps and only list, for brevity. I also upgraded the test-script for python 3 and added my win64 debug build bat. But it looks like theres allready a pull request with python upgrade in from a few weeks ago.