### PR TITLE
Fixed using absolute paths for the make scripts on windows

### DIFF
--- a/make_win32_mingw.bat
+++ b/make_win32_mingw.bat
@@ -1,3 +1,6 @@
+set curpath=%CD%
+cd "%~dp0"
 @gcc -ansi -pedantic -Wall src/tools/txt2c.c -o src/tools/txt2c
 @src\tools\txt2c.exe src/base.lua src/tools.lua src/driver_gcc.lua src/driver_clang.lua src/driver_cl.lua src/driver_solstudio.lua src/driver_xlc.lua > src/internal_base.h
 @gcc -pedantic -Wall src/*.c src/lua/*.c -o bam -I src/lua/
+cd %curpath%

--- a/make_win32_msvc.bat
+++ b/make_win32_msvc.bat
@@ -43,6 +43,8 @@ pause
 exit
 
 :compile
+set curpath=%CD%
+cd "%~dp0"
 @echo === building bam ===
 @cl /D_CRT_SECURE_NO_DEPRECATE /O2 /nologo src/tools/txt2c.c /Fesrc/tools/txt2c.exe
 @src\tools\txt2c src/base.lua src/tools.lua src/driver_gcc.lua src/driver_clang.lua src/driver_cl.lua src/driver_solstudio.lua src/driver_xlc.lua > src\internal_base.h
@@ -57,8 +59,8 @@ exit
 @REM /LTCG = link time code generation
 @cl /D_CRT_SECURE_NO_DEPRECATE /DLUA_BUILD_AS_DLL /W3 /O2 /TC /Zi /GS- /GL /nologo /I src/lua src/*.c src/lua/*.c /Febam.exe /link Advapi32.lib /LTCG
 
-@IF %errorlevel% NEQ 0 exit /B 1
-
 @REM clean up
 @del bam.exp
 @del *.obj
+cd %curpath%
+@IF %errorlevel% NEQ 0 exit /B 1

--- a/make_win64_msvc.bat
+++ b/make_win64_msvc.bat
@@ -43,6 +43,8 @@ pause
 exit
 
 :compile
+set curpath=%CD%
+cd "%~dp0"
 @echo === building bam ===
 @cl /D_CRT_SECURE_NO_DEPRECATE /O2 /nologo src/tools/txt2c.c /Fesrc/tools/txt2c.exe
 @src\tools\txt2c src/base.lua src/tools.lua src/driver_gcc.lua src/driver_clang.lua src/driver_cl.lua src/driver_solstudio.lua src/driver_xlc.lua > src\internal_base.h
@@ -57,8 +59,8 @@ exit
 @REM /LTCG = link time code generation
 @cl /D_CRT_SECURE_NO_DEPRECATE /DLUA_BUILD_AS_DLL /W3 /O2 /TC /Zi /GS- /GL /nologo /I src/lua src/*.c src/lua/*.c /Febam.exe /link Advapi32.lib /LTCG
 
-@IF %errorlevel% NEQ 0 exit /B 1
-
 @REM clean up
 @del bam.exp
 @del *.obj
+cd %curpath%
+@IF %errorlevel% NEQ 0 exit /B 1


### PR DESCRIPTION
Changes the current path to the script folder and switches back when the job is done.
Fixes #130