### PR TITLE
Build Objective C++ files (.mm)

### DIFF
--- a/src/tools.lua
+++ b/src/tools.lua
@@ -333,6 +333,7 @@ AddTool(function (settings)
 	InitCommonCCompiler(settings)
 	settings.compile.mappings["c"] = CompileC
 	settings.compile.mappings["m"] = CompileC
+	settings.compile.mappings["mm"] = CompileC
 	settings.compile.mappings["S"] = CompileC
 	settings.compile.mappings["s"] = CompileC
 end)


### PR DESCRIPTION
This change allows Objective C++ files to be compiled with bam. This allows Objective C constructs to be mixed by C++ constructs for an unholy combination of evils