### PR TITLE
A hack in Execute() to cover for an issue in lua os.execute where the…

### DIFF
--- a/src/base.lua
+++ b/src/base.lua
@@ -71,6 +71,13 @@ end
 @END]]--
 function Execute(command)
 	local res,str,code = os.execute(command)
+	if family == 'windows' then
+		if not res and code == 0 then
+		-- if the program returns -1, system() returns -1, but that is what it returns when it set errno, so lua os.execute returns errno, but that is 0. Such a mess, but we really don't wan't to return 0 for failed calls
+		-- there was some talk about it on the lua mainling list (http://lua-users.org/lists/lua-l/2018-05/msg00045.html), but the latest 5.4 beta has no fixes.
+			return -1 
+		end
+	end
 	return code
 end
 


### PR DESCRIPTION
A hack in Execute() to cover for an issue in lua os.execute where the return code would be 0 if the called program returns -1. Not sure it's a reasonable approach, but as is Execute() in bam return 0 if it calls bam with a broken argument, as bam return -1 for that. 

If the program returns -1, system() returns -1, but that is what it returns when it set errno, so lua os.execute returns errno, but that is 0. Such a mess, but we really don't wan't to return 0 for failed calls.
There was some talk about it on the lua mainling list a year ago (http://lua-users.org/lists/lua-l/2018-05/msg00045.html), but the latest 5.4 beta has no fixes.
