### PR TITLE
debug-nodes tweaks

### DIFF
--- a/src/node.c
+++ b/src/node.c
@@ -807,6 +807,7 @@ void node_debug_dump(struct GRAPH *graph, int html)
 		job = *jobiter;
 		printf("JOB %s\n", decorate_header(job->id, job->label, "j", html));
 		printf("CMD %s\n", job->cmdline);
+		printf("PRIORIY %d\n", job->priority);
 		
 		nodelist = sorted_nodelinklist(job->firstoutput);
 		for(node = nodelist; *node; node++)


### PR DESCRIPTION
*Sort jobs on the alphabetically first output, to be able to diff --debug-nodes outputs between changes and still se what is going on.

*Print the job prio

A bit of a hack, but I'll use it localy untill something better is implemented, apply or discard:
*As a band-aid, print the output deps once for the job, and not per output, as they can't be very to read as is (like a link step with 1000 obj files and 4 outputs. (Drops output frpm 32 to 26MiB). Maybe the right solution would be to print all the "common" deps and parents first, and then the stuff isn't the same for all under each output. Deps are always the same, parents are usually but not allways. Not sure about the constraints, the jobs constraint should be the union of all, like deps?

