### PR TITLE
Fix for the false positive "from the future" checks.

### DIFF
--- a/src/context.c
+++ b/src/context.c
@@ -553,8 +553,9 @@ static int build_prepare_callback(struct NODEWALK *walkinfo)
 	int olddirty = node->dirty;
 	struct NODELINK *oldjobdep = node->job->firstjobdep;
 
-	/* time sanity check */
-	if(node->timestamp > context->buildtime)
+	/* 	time sanity check 
+		files may have been written by the script, so compare to the global time after setup */
+	if(node->timestamp > context->postsetuptime )
 		printf("%s: warning:'%s' comes from the future\n", session.name, node->filename);
 	
 	if(node->job->cmdline)

--- a/src/context.h
+++ b/src/context.h
@@ -55,6 +55,7 @@ struct CONTEXT
 	
 	time_t globaltimestamp;		/* timestamp of the script files */
 	time_t buildtime;			/* timestamp when the build started */
+	time_t postsetuptime;		/* timestamp after the setup when script has run to completion etc */
 
 	/* debugging */
 	struct VERIFY_STATE *verifystate;

--- a/src/main.c
+++ b/src/main.c
@@ -815,6 +815,9 @@ static int bam(const char *scriptfile, const char **targets, int num_targets)
 	/* close the lua state */
 	lua_close(context.lua);
 	
+	/* time after script has run to completion etc */
+	context.postsetuptime = timestamp();
+
 	/* do actions if we don't have any errors */
 	if(!setup_error)
 	{


### PR DESCRIPTION
Compare with the time that is after setup/script has run when checking if a file is from the future. This way bam doesn't complain about files generated by the script.