### PR TITLE
Set SetDriversDefault in global scope 

### DIFF
--- a/src/tools.lua
+++ b/src/tools.lua
@@ -1,4 +1,5 @@
 _checked_default_drivers = false
+SetDriversDefault = false
 
 function SetDefaultDrivers(settings)
 	-- check for compilers first time


### PR DESCRIPTION
(to 'false', I don't don't know what we should set it to, as 'nil' doesn't work). This so SetDefaultDrivers don't sets new keys in global table runtime to support locking of global table.

Or something, just annoying to work around when you want to lock the global lua table.