### PR TITLE
Fixed so scancache works for headers that include no other headers.

### DIFF
--- a/src/cache.h
+++ b/src/cache.h
@@ -3,6 +3,7 @@
 struct GRAPH;
 struct DEPCACHE;
 struct SCANCACHE;
+struct CHEADERREF;
 struct OUTPUTCACHE; /* bad name */
 struct CONTEXT;
 struct NODE;
@@ -28,7 +29,7 @@ int depcache_do_dependency(
 */
 int scancache_save(const char *filename, struct GRAPH *graph);
 struct SCANCACHE *scancache_load(const char *filename);
-struct CHEADERREF *scancache_find(struct SCANCACHE *scancache, struct NODE * node);
+int scancache_find(struct SCANCACHE *scancache, struct NODE * node, struct CHEADERREF** result);
 void scancache_free(struct SCANCACHE *scancache);
 
 /*

--- a/src/dep_cpp2.c
+++ b/src/dep_cpp2.c
@@ -118,8 +118,9 @@ static int scan_source_file(struct CONTEXT * context, struct NODE *node)
 	node->headerscanned = 1;
 
 	/* check the cache first */
-	node->firstcheaderref = scancache_find(context->scancache, node);
-	if ( node->firstcheaderref ) {
+	if(scancache_find(context->scancache, node, &node->firstcheaderref) == 0)
+	{
+		node->headerscannedsuccess = 1;
 		return 0;
 	}
 
@@ -184,6 +185,7 @@ static int scan_source_file(struct CONTEXT * context, struct NODE *node)
 
 	/* clean up and return */
 	free(filebuf);
+	node->headerscannedsuccess = 1;
 	return 0;
 }
 

--- a/src/main.c
+++ b/src/main.c
@@ -646,7 +646,7 @@ static int bam_setup(struct CONTEXT *context, const char *scriptfile, const char
 			}
 		}
 	}
-	event_end(0, "deferred cpp dependencies", NULL);
+	event_end(0, "deferred cpp dependencies 2", NULL);
 		
 	event_begin(0, "deferred search dependencies", NULL);
 	if(run_deferred_functions(context, context->firstdeferred_search) != 0)

--- a/src/node.h
+++ b/src/node.h
@@ -127,6 +127,7 @@ struct NODE
 	unsigned cached:1; /* set if the node should be considered as cached */
 	unsigned skipverifyoutput:1; /* set if we don't want to skip the output verification for this output  */
 	unsigned headerscanned:1; /* set if a dependency checker have processed the file */
+	unsigned headerscannedsuccess:1; /* set if a dependency checker have processed the file, and it could be scanned*/
 };
 
 /* cache node */


### PR DESCRIPTION
Previously the test if it was in the cache was if there was any refs, but that meant that if the scanned header didn't have any includes it would always be rescanned.