### PR TITLE
Runtime stat cache

### DIFF
--- a/src/context.h
+++ b/src/context.h
@@ -36,6 +36,8 @@ struct CONTEXT
 	struct OUTPUTCACHE *outputcache;
 	struct SCANCACHE *scancache;
 
+	struct STATCACHE *statcache;
+
 	/* targets */
 	struct NODE *defaulttarget;	/* default target if no targets are specified */
 	struct NODE *target;		/* target to build */

--- a/src/main.c
+++ b/src/main.c
@@ -20,6 +20,7 @@
 #include "support.h"
 #include "context.h"
 #include "cache.h"
+#include "statcache.h"
 #include "luafuncs.h"
 #include "platform.h"
 #include "session.h"
@@ -768,6 +769,7 @@ static int bam(const char *scriptfile, const char **targets, int num_targets)
 	context.graphheap = mem_create();
 	context.deferredheap = mem_create();
 	context.graph = node_graph_create(context.graphheap);
+	context.statcache = statcache_create();
 	context.exit_on_error = option_abort_on_error;
 	context.buildtime = timestamp();
 
@@ -894,6 +896,7 @@ static int bam(const char *scriptfile, const char **targets, int num_targets)
 	mem_destroy(context.graphheap);
 	free(context.joblist);
 	depcache_free(context.depcache);
+	statcache_free(context.statcache);
 
 	if(context.verifystate)
 	{

--- a/src/statcache.c
+++ b/src/statcache.c
@@ -1,0 +1,97 @@
+#include <string.h> /* memset */
+#include <stdlib.h> /* malloc */
+#include <stdio.h> /* printf */
+#include <errno.h>
+
+#include "statcache.h"
+#include "support.h"
+#include "mem.h"
+#include "path.h"
+
+#define STATCACHE_HASH_SIZE (16*1024)
+
+struct STATCACHE_ENTRY
+{
+	hash_t hashid;
+	time_t timestamp;
+	unsigned int isregular:1;
+	struct STATCACHE_ENTRY* next;
+};
+
+struct STATCACHE
+{
+	struct HEAP* heap;
+	struct STATCACHE_ENTRY* entries[STATCACHE_HASH_SIZE];
+};
+
+struct STATCACHE* statcache_create()
+{
+	struct STATCACHE* statcache = malloc(sizeof(struct STATCACHE));
+	memset(statcache, 0, sizeof(struct STATCACHE));
+
+	statcache->heap = mem_create();
+	return statcache;
+}
+
+void statcache_free(struct STATCACHE* statcache)
+{
+	if(!statcache)
+		return;
+	mem_destroy(statcache->heap);
+	free( statcache );
+}
+
+struct STATCACHE_ENTRY* statcache_getstat_int(struct STATCACHE* statcache, const char* filename)
+{
+	hash_t namehash = string_hash( filename );
+	int hashindex = namehash & ( STATCACHE_HASH_SIZE - 1 );
+
+	struct STATCACHE_ENTRY* entry = NULL;
+	for ( entry = statcache->entries[ hashindex ]; entry; entry = entry->next ) {
+		if ( entry->hashid == namehash ) {
+			break;
+		}
+	}
+
+	if ( !entry ) {
+		entry = ( struct STATCACHE_ENTRY* )mem_allocate( statcache->heap, sizeof( struct STATCACHE_ENTRY ) );
+		entry->hashid = namehash;
+		entry->timestamp = file_timestamp( filename );
+		if ( entry->timestamp != 0 ) {
+			entry->isregular = file_isregular( filename );
+		}
+		entry->next = statcache->entries[ hashindex ];
+		statcache->entries[ hashindex ] = entry;
+	}
+	return entry;
+}
+
+int statcache_getstat(struct STATCACHE* statcache, const char* filename, time_t* timestamp, int* isregularfile)
+{
+	if(!statcache)
+		return 1;
+	
+	// check if the folder exists first. Many files share the same folder path,
+	// so this check is likely to hit the cache even if the full path is unique
+	// total number stats is 38% of what it was without in my (large, actual project) test
+	char dirname[MAX_PATH_LENGTH];
+	if(path_directory(filename, dirname, MAX_PATH_LENGTH) == 0 && dirname[0] != '\0')
+	{
+		struct STATCACHE_ENTRY* direntry = statcache_getstat_int(statcache, dirname);
+		if(direntry)
+		{
+			if(direntry->timestamp == 0)
+			{
+				*timestamp = 0;
+				*isregularfile = 0;
+				return 0;
+			}
+		}
+	}
+	
+	struct STATCACHE_ENTRY* entry = statcache_getstat_int(statcache, filename);
+	
+	*timestamp=entry->timestamp;
+	*isregularfile = entry->isregular;
+	return 0;
+}

--- a/src/statcache.c
+++ b/src/statcache.c
@@ -15,6 +15,7 @@ struct STATCACHE_ENTRY
 	hash_t hashid;
 	time_t timestamp;
 	unsigned int isregular:1;
+	unsigned int isdir:1;
 	struct STATCACHE_ENTRY* next;
 };
 
@@ -56,9 +57,12 @@ struct STATCACHE_ENTRY* statcache_getstat_int(struct STATCACHE* statcache, const
 	if ( !entry ) {
 		entry = ( struct STATCACHE_ENTRY* )mem_allocate( statcache->heap, sizeof( struct STATCACHE_ENTRY ) );
 		entry->hashid = namehash;
-		entry->timestamp = file_timestamp( filename );
-		if ( entry->timestamp != 0 ) {
-			entry->isregular = file_isregular( filename );
+		unsigned int isregular = 0;
+		unsigned int isdir = 0;
+		if(file_stat(filename, &entry->timestamp, &isregular, &isdir) == 0)
+		{
+			entry->isregular = isregular;
+			entry->isdir = isdir;
 		}
 		entry->next = statcache->entries[ hashindex ];
 		statcache->entries[ hashindex ] = entry;

--- a/src/statcache.h
+++ b/src/statcache.h
@@ -1,0 +1,13 @@
+#include "support.h"
+
+struct STATCACHE;
+
+/*
+	Runtime file stat cache
+	So we don't have to stat a file more than once per run.
+*/
+
+struct STATCACHE* statcache_create();
+void statcache_free(struct STATCACHE* statcache);
+int statcache_getstat(struct STATCACHE* statcache, const char* filename, time_t* timestamp, int* isregularfile);
+

--- a/src/support.c
+++ b/src/support.c
@@ -522,6 +522,32 @@ int file_isdir(const char *filename)
 	return 0;
 }
 
+int file_stat(const char *filename, time_t* stamp, unsigned int* isregular, unsigned int* isdir)
+{
+	struct stat s;
+	if (stat(filename, &s) != 0)
+	{
+		*stamp = 0;
+		*isregular = 0;
+		*isdir = 0;
+		return 1;
+	}
+#ifdef BAM_FAMILY_WINDOWS
+	*stamp = s.st_mtime;
+	*isregular = (s.st_mode&_S_IFREG) != 0;
+	*isdir = (s.st_mode&_S_IFDIR) != 0;
+#elif BAM_PLATFORM_MACOSX
+	*stamp = s.st_mtimespec.tv_sec;
+	*isregular = S_ISREG(s.st_mode);
+	*isdir = S_ISDIR(s.st_mode);
+#else
+	*stamp = s.st_mtime;
+	*isregular = S_ISREG(s.st_mode);
+	*isdir = S_ISDIR(s.st_mode);
+#endif
+	return 0;
+}
+
 int file_createdir(const char *path)
 {
 	int r;

--- a/src/support.h
+++ b/src/support.h
@@ -66,6 +66,7 @@ time_t timestamp();
 time_t file_timestamp(const char *filename);
 int file_isregular(const char *path);
 int file_isdir(const char *path);
+int file_stat(const char *filename, time_t* stamp, unsigned int* isregular, unsigned int* isdir); 
 int file_createdir(const char *path);
 int file_createpath(const char *output_name);
 void file_touch(const char *filename);


### PR DESCRIPTION
 Added a runtime statcache to try to bring cdep2 to a usable speed. 37.6->3.7s (with the combined stat) in my large real-world test. Only used by cdep2 now, but can be used for other things easily.
