### PR TITLE
Sort jobs and nodes first case-insensitive in debug-nodes

### DIFF
--- a/src/node.c
+++ b/src/node.c
@@ -618,6 +618,9 @@ void node_walk_revisit(struct NODEWALK *walk, struct NODE *node)
 /* compares the filenames for a stable sorting of nodes during output */
 static int node_compare(const void * a, const void * b)
 {
+	int ci_diff = string_compare_case_insensitive( (*(const struct NODE **)a)->filename, (*(const struct NODE **)b)->filename);
+	if(ci_diff != 0)
+		return ci_diff;
 	return strcmp((*(const struct NODE **)a)->filename, (*(const struct NODE **)b)->filename);
 }
 
@@ -648,6 +651,9 @@ static int job_compare(const void * a, const void * b)
 	struct NODE* outputa = node_find_sorted_first((*(const struct JOB**)a)->firstoutput);
 	struct NODE* outputb = node_find_sorted_first((*(const struct JOB**)b)->firstoutput);
 	
+	int ci_diff = string_compare_case_insensitive(outputa->filename, outputb->filename);
+	if(ci_diff != 0)
+		return ci_diff;
 	return strcmp(outputa->filename, outputb->filename);
 }
 

--- a/src/support.c
+++ b/src/support.c
@@ -797,7 +797,6 @@ char *string_duplicate(struct HEAP *heap, const char *src, size_t len)
 }
 
 /* */
-#ifdef BAM_FAMILY_WINDOWS
 /* on windows, we need to handle that filenames with mixed casing are the same.
 	to solve this we have this table that converts all uppercase letters.
 	in addition to this, we also convert all '\' to '/' to remove that
@@ -821,6 +820,7 @@ static const unsigned char tolower_table[256] = {
 224, 225, 226, 227, 228, 229, 230, 231, 232, 233, 234, 235, 236, 237, 238, 239,
 240, 241, 242, 243, 244, 245, 246, 247, 248, 249, 250, 251, 252, 253, 254, 255};
 
+#ifdef BAM_FAMILY_WINDOWS
 hash_t string_hash_add(hash_t h, const char *str_in)
 {
 	const unsigned char *str = (const unsigned char *)str_in;
@@ -848,6 +848,17 @@ void string_hash_tostr(hash_t value, char *output)
 	sprintf(output, "%08x%08x", (unsigned)(value>>32), (unsigned)(value&0xffffffff));
 }
 
+int string_compare_case_insensitive( const char* str_a, const char* str_b )
+{
+	int d;
+	for(; *str_a && *str_b; str_a++, str_b++ )
+	{
+		d = (int)tolower_table[(int)*(str_a)] - (int)tolower_table[(int)*(str_b)];
+		if(d != 0)
+			return d;
+	};
+	return (int)*str_a - (int)*str_b; // we are just comparing 0/ so no decasing necessary
+}
 
 static int64 starttime = 0;
 

--- a/src/support.h
+++ b/src/support.h
@@ -74,6 +74,7 @@ void file_listdirectory(const char *path, void (*callback)(const char *fullpath,
 
 /* string helper functions */
 char *string_duplicate(struct HEAP *heap, const char *src, size_t len);
+int string_compare_case_insensitive( const char* str_a, const char* str_b );
 
 /* string hashing function */
 hash_t string_hash(const char *str_in);


### PR DESCRIPTION
Sort jobs and nodes first case-insensitive and then sensitive if equal, so nodes don't move when they change case (case can be dep-check order dependent on windows).

This means that the nodes for blabla\QT\derp.h and blabla\qt\herp.h will be printed in the same part of the output. It's very hard to se what is actually chaning when a few hundred nodes moves ten thousand lines in the output between runs with minor changes.

(this commit was linked in a comment on the other debug-nodes pull request https://github.com/matricks/bam/pull/141), but I guess it got overlooked).

