### PR TITLE
fix macOS build

### DIFF
--- a/src/support.h
+++ b/src/support.h
@@ -85,4 +85,6 @@ void string_hash_tostr(hash_t value, char *output);
 void event_begin(int thread, const char *name, const char *data);
 void event_end(int thread, const char *name, const char *data);
 
+int raise(int signal);
+
 #endif


### PR DESCRIPTION

```
src/support.c:729:3: error: implicit declaration of function 'raise' is invalid in C99 [-Werror,-Wimplicit-function-declaration]
```
