### PR TITLE
Do not overwrite the global "s" in "Import".

### DIFF
--- a/src/base.lua
+++ b/src/base.lua
@@ -445,7 +445,7 @@ end
 function Import(filename)
 	local paths = {"", PathDir(ModuleFilename())}
 
-	s = os.getenv("BAM_PACKAGES")
+	local s = os.getenv("BAM_PACKAGES")
 	if s then
 		for w in string.gmatch(s, "[^:]*") do
 			if string.len(w) > 0 then


### PR DESCRIPTION
After a call to "Import" one of my globals was gone. These 2 files show the problem.

bam.lua:
```lua
s = 'abc'
print('s before Import: ', s)
Import('sub.lua')
print('s after Import: ', s)
```

sub.lua:
```lua
print('s in sub.lua: ', s)
```

I would expect that all 3 print statements show the value of "abc". But this is only true for the first print:
```
huhn@asteroid:~/workspace/bam_experiments/test_import$ ./bam
s before Import: 	abc
s in sub.lua: 	nil
s after Import: 	nil
bam: targets are up to date already
```

s gets the value from the environment variable "BAM_PACKAGES":
```
huhn@asteroid:~/workspace/bam_experiments/test_import$ BAM_PACKAGES="booh" ./bam_org 
s before Import: 	abc
s in sub.lua: 	booh
s after Import: 	booh
bam: targets are up to date already
```