### PR TITLE
Fixed memory issues when compiling with GCC

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -113,6 +113,9 @@ struct SESSION session = {
 	0 /* rest */
 };
 
+/* storage for parameters */
+static char parameters_buffer[1024] = {0};
+
 static struct OPTION options[] = {
 	/*@OPTION Targets ( name )
 		Specify a target to be built. A target can be any output
@@ -1037,10 +1040,9 @@ static int parse_parameters_str(const char *str)
 {
 	char *ptrs[64];
 	int num_ptrs = 0;
-	char buffer[1024];
-	char *start = buffer;
+	char *start = parameters_buffer;
 	char *current = start;
-	char *end = buffer+sizeof(buffer);
+	char *end = parameters_buffer+sizeof(parameters_buffer);
 	int string_parse = 0;
 	
 	ptrs[0] = start;

--- a/src/support.c
+++ b/src/support.c
@@ -378,9 +378,9 @@
 			stat(buffer, &info);
 			isdir = S_ISDIR(info.st_mode);
 #endif
-			free(entry);
 			/* call the callback */
 			callback(buffer, entry->d_name, isdir, user);
+			free(entry);
 		}
 		
 		free(namelist);


### PR DESCRIPTION
```
export BAM_OPTIONS="-j 4"
bam
```

This did not work because a corrupted string would be passed to atoi() here:

`session.threads = atoi(option_threads_str);`

which would cause `session.threads` to always be 0.