### PR TITLE
Remove 'u' flag from ar command line to avoid warning with GNU ar 2.44

### DIFF
--- a/make_msys2.sh
+++ b/make_msys2.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+
+case "$(uname)" in
+	*BSD) ccorder='clang gcc'; ldl=       ;;
+	   *) ccorder='gcc clang'; ldl='-ldl' ;;
+esac
+
+# auto detection of compiler
+if [ -z "$CC" ]; then
+	for cctry in $ccorder; do
+		if $cctry --version > /dev/null 2>&1; then
+			CC=$cctry
+			break;
+		fi
+	done
+
+	if [ -z "$CC" ]; then
+		echo "No compiler found. Specify compiler by setting the CC environment variable." >&2
+		echo "Example: CC=gcc ./$0" >&2
+		exit 1
+	fi
+fi
+
+# the actual compile
+echo "compiling using $CC..." >&2
+$CC -Wall -pedantic -O1 src/tools/txt2c.c -o src/tools/txt2c
+src/tools/txt2c src/base.lua src/tools.lua src/driver_gcc.lua src/driver_clang.lua src/driver_cl.lua src/driver_solstudio.lua src/driver_xlc.lua > src/internal_base.h
+$CC -w -pedantic src/*.c src/lua/*.c -o bam -I src/lua -Os -s -flto $*

--- a/src/base.lua
+++ b/src/base.lua
@@ -455,7 +455,7 @@ end
 	[ModuleFilename] function.
 @END]]--
 function Import(filename)
-	local paths = {"", PathDir(ModuleFilename())}
+	local paths = {PathDir(ModuleFilename()), ""}
 
 	local s = os.getenv("BAM_PACKAGES")
 	if s then

--- a/src/driver_gcc.lua
+++ b/src/driver_gcc.lua
@@ -53,7 +53,7 @@ end
 function DriverGCC_Lib(output, inputs, settings)
 	-- output archive must be removed because ar will update existing archives, possibly leaving stray objects
 	local e = "rm -f " .. output .. " 2> /dev/null; "
-	local e = e .. settings.lib.exe .. " rcu " .. output
+	local e = e .. settings.lib.exe .. " rc " .. output
 	local e = e .. " " .. TableToString(inputs, '', ' ') .. settings.lib.flags:ToString()
 	return e
 end


### PR DESCRIPTION
Remove 'u' flag from ar command line to avoid warning with GNU ar 2.44: "'u' modifier ignored since 'D' is the default (see 'U')".

This flag is also seem unnecessary here as the archive is deleted before creation
making update checks redundant. Also tested with BSD ar and llvm-ar.
