### PR TITLE
Prioritize script directory for Import() resolution

### DIFF
--- a/src/base.lua
+++ b/src/base.lua
@@ -455,7 +455,7 @@ end
 	[ModuleFilename] function.
 @END]]--
 function Import(filename)
-	local paths = {"", PathDir(ModuleFilename())}
+	local paths = {PathDir(ModuleFilename()), ""}
 
 	local s = os.getenv("BAM_PACKAGES")
 	if s then


### PR DESCRIPTION
Fix annoying problem where you have nested bam.lua files that include each other.

For example given the directory tree A/B/C

/A/B $ bam -s C/bam.lua

If "C/bam.lua" imports "../bam.lua" but there also exists a "../bam.lua" relative to CWD it would prioritize bam.lua relative to CWD. Expected result from the script in C is to include B/bam.lua but instead it would include A/bam.lua